### PR TITLE
fix(portal): Clear button clears the server-side activity log

### DIFF
--- a/pi/portal.py
+++ b/pi/portal.py
@@ -1733,6 +1733,12 @@ class Handler(http.server.BaseHTTPRequestHandler):
         if path == "/api/udplog":
             _udp_log.clear()
             self._send_json({"ok": True})
+        elif path == "/api/log":
+            # The dashboard "Clear" button only emptied the browser DOM; the next
+            # poll re-fetched the retained entries so the activity log reappeared.
+            # Clear the server-side log so the Clear actually sticks.
+            activity_log.clear()
+            self._send_json({"ok": True})
         elif path == "/api/firmware/delete":
             self._handle_firmware_delete()
         else:
@@ -3616,7 +3622,10 @@ async function enterPortal() {
     setTimeout(() => { btn.disabled = false; btn.textContent = 'Enter Captive Portal'; }, 30000);
 }
 
-function clearLog() {
+async function clearLog() {
+    // Clear the server-side log first, else the next poll re-fetches the retained
+    // entries (resetting lastLogTs alone pulls the whole log back).
+    try { await fetch('/api/log', { method: 'DELETE' }); } catch (e) { /* ignore */ }
     document.getElementById('log-entries').innerHTML = '';
     lastLogTs = '';
 }


### PR DESCRIPTION
## Problem
The Activity Log **Clear** button only emptied the browser DOM. On the next poll the client re-fetched the retained server-side entries, so the activity log immediately reappeared — the Clear never "stuck".

## Fix
- Add a `DELETE /api/log` route that calls `activity_log.clear()`.
- Make the front-end `clearLog()` issue that DELETE before clearing the DOM and resetting the `lastLogTs` cursor.

Two small hunks in `pi/portal.py`; `python -m py_compile pi/portal.py` is clean.

## Verification
This mirrors the fix already running on my bench portal: after clicking **Clear**, the log empties and stays empty across subsequent polls.