### PR TITLE
fix(install): drop stale cw_beacon.py copy (retired in c8ca09a)

### DIFF
--- a/pi/install.sh
+++ b/pi/install.sh
@@ -90,7 +90,6 @@ cp "$SCRIPT_DIR/portal.py"                  /usr/local/bin/rfc2217-portal
 cp "$SCRIPT_DIR/plain_rfc2217_server.py"    /usr/local/bin/plain_rfc2217_server.py
 cp "$SCRIPT_DIR/wifi_controller.py"         /usr/local/bin/wifi_controller.py
 cp "$SCRIPT_DIR/ble_controller.py"          /usr/local/bin/ble_controller.py
-cp "$SCRIPT_DIR/cw_beacon.py"              /usr/local/bin/cw_beacon.py
 cp "$SCRIPT_DIR/bcm_gpio.py"                /usr/local/bin/bcm_gpio.py
 cp "$SCRIPT_DIR/gpclk.py"                   /usr/local/bin/gpclk.py
 cp "$SCRIPT_DIR/morse.py"                   /usr/local/bin/morse.py


### PR DESCRIPTION
## Problem
`pi/install.sh` still copies `pi/cw_beacon.py`, but that file was removed when the legacy CW beacon API was retired (c8ca09a). Under `set -e`, the missing-file `cp` aborts the script mid-run — both a fresh `install.sh` and `install.sh --update` die before the portal service is restarted (line 89 copies portal.py, then it aborts at the cw_beacon line before the systemctl restart).

## Fix
Remove the dead `cp cw_beacon.py` line. `bash -n` clean.

## Verification
Ran `sudo bash pi/install.sh --update` on a Pi after this change: it completes cleanly, the portal service comes back `active`, and `/api/devices` serves all slots.