### PR TITLE
Add POST /api/serial/write (FR-030)

### DIFF
--- a/docs/Embedded-Workbench-FSD.md
+++ b/docs/Embedded-Workbench-FSD.md
@@ -323,6 +323,7 @@ jack count, and add any unoccupied prefix(es) to the table.
 | GET | /api/info | Pi IP, hostname, slot counts |
 | POST | /api/serial/reset | Reset device via DTR/RTS (FR-008) |
 | POST | /api/serial/monitor | Read serial output with pattern match (FR-009) |
+| POST | /api/serial/write | Write to serial input and read the reply (FR-030) |
 
 **GET /api/devices** returns:
 
@@ -747,6 +748,55 @@ Uses the RFC2217 proxy (non-exclusive) so the proxy stays running.
 
 **Used by:** flapping recovery (FR-007), test verification
 
+### FR-030 — Serial Write
+
+Send input to a device and capture its reply.  FR-009 covers reading only;
+without a write path a DUT that asks a question over serial cannot be
+answered, so any prompt-driven flow (LoRaWAN key provisioning, a firmware
+CLI, a config menu) is unreachable through the API.
+
+**Endpoint:** `POST /api/serial/write`
+
+**Request body:**
+```json
+{"slot": "SLOT2", "data": "AT+JOIN", "newline": "\r\n", "expect": "OK", "timeout": 10}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| slot | string | Yes | — | Slot label (e.g. "SLOT2") |
+| data | string | Yes | — | Text to send, without a line ending |
+| newline | string | No | `"\n"` | Line ending: `"\n"`, `"\r\n"`, `"\r"`, or `""` for none |
+| expect | string | No | null | Substring to wait for in the reply |
+| timeout | number | No | 10 | Max seconds to wait for the reply |
+
+**Procedure:**
+1. Connect to the slot's RFC2217 proxy (non-exclusive)
+2. Write `data + newline`, then flush
+3. Read reply lines until `expect` matches or timeout expires
+4. Return bytes written, captured output, and match result
+
+The write and the read-back share one proxy connection by design.  The proxy
+serves a single client at a time and nothing drains the port between calls,
+so issuing a bare write and then a separate FR-009 monitor would discard
+whatever the device emitted while no client was attached — which for a
+prompt/response exchange is the entire reply.
+
+**Response (expect matched):**
+```json
+{"ok": true, "written": 9, "matched": true, "line": "OK", "output": ["AT+JOIN", "OK"]}
+```
+
+**Response (no expect given):**
+```json
+{"ok": true, "written": 9, "matched": false, "line": null, "output": ["AT+JOIN"]}
+```
+
+Local echo is common — the DUT usually echoes the sent line back, so `output`
+will often lead with `data` itself.
+
+**Used by:** device provisioning, firmware CLI interaction
+
 ### FR-007 — USB Flap Detection & Recovery
 
 When a device enters a boot loop (crash → reboot → crash every ~2-3s), the
@@ -895,6 +945,7 @@ serial-interface mode.
 | GET | /api/info | Pi IP, hostname, slot counts |
 | POST | /api/serial/reset | Reset device via DTR/RTS (FR-008) |
 | POST | /api/serial/monitor | Read serial output with pattern match (FR-009) |
+| POST | /api/serial/write | Write to serial input and read the reply (FR-030) |
 | **WiFi** | | |
 | GET | /api/wifi/ping | Version and uptime |
 | GET | /api/wifi/mode | Current operating mode |

--- a/mcp/workbench_mcp.py
+++ b/mcp/workbench_mcp.py
@@ -66,6 +66,17 @@ SPECS = [
          desc="Read serial for up to `timeout` s, optionally returning when `pattern` matches.",
          props=p(slot=S_STR, pattern=S_STR, timeout=dict(**S_INT, default=10)),
          required=["slot"], timeout=90),
+    dict(name="serial_write", method="POST", path="/api/serial/write",
+         desc="Write a line to the DUT's serial input, then read the reply "
+              "(optionally until `expect` matches). Use for prompt-driven "
+              "flows like LoRaWAN key provisioning or a firmware CLI.",
+         props=p(slot=S_STR,
+                 data=dict(**S_STR, description="text to send, without newline"),
+                 newline=dict(**S_STR, default="\n",
+                              description=r"line ending: '\n', '\r\n', '\r', or '' for none"),
+                 expect=dict(**S_STR, description="substring to wait for in the reply"),
+                 timeout=dict(**S_INT, default=10)),
+         required=["slot", "data"], timeout=90),
     dict(name="serial_output", method="GET", path="/api/serial/output",
          desc="Passive read of the slot's serial buffer.",
          props=p(slot=S_STR, lines=dict(**S_INT, default=40), since=S_INT), required=["slot"]),

--- a/pi/portal.py
+++ b/pi/portal.py
@@ -1417,6 +1417,69 @@ def serial_monitor(slot: dict, pattern: str | None = None,
     }
 
 
+def serial_write(slot: dict, data: str, newline: str = "\n",
+                 expect: str | None = None, timeout: float = 10.0) -> dict:
+    """FR-030: Write to a device's serial input via the RFC2217 proxy.
+
+    Writes *data* + *newline*, then reads back until *expect* matches or
+    *timeout* expires.
+
+    The write and the read-back deliberately share one proxy connection: the
+    proxy accepts a single client at a time and nothing drains the port
+    in between, so a bare write followed by a separate /api/serial/monitor
+    call would lose everything the device emitted while no client was
+    attached.  Prompt-driven flows (provisioning, CLI firmware) need the
+    response that arrives microseconds after the write.
+
+    Returns {"ok": True, "written": N, "matched": bool, "line": str|None,
+             "output": [...]}.
+    """
+    import serial as pyserial
+
+    label = slot["label"]
+    tcp_port = slot.get("tcp_port")
+
+    if not tcp_port:
+        return {"ok": False, "error": f"{label}: no tcp_port configured"}
+    if not slot.get("running"):
+        return {"ok": False, "error": f"{label}: proxy not running"}
+
+    payload = (data + newline).encode("utf-8", errors="replace")
+
+    rfc2217_url = f"rfc2217://127.0.0.1:{tcp_port}"
+    try:
+        ser = pyserial.serial_for_url(rfc2217_url, do_not_open=True)
+        ser.baudrate = 115200
+        ser.timeout = 0.1
+        ser.dtr = False
+        ser.rts = False
+        ser.open()
+    except Exception as e:
+        return {"ok": False, "error": f"Cannot connect to {rfc2217_url}: {e}"}
+
+    slot["state"] = STATE_MONITORING
+    try:
+        written = ser.write(payload)
+        ser.flush()
+        lines, matched_line = _read_serial_lines(ser, expect, timeout)
+    except Exception as e:
+        return {"ok": False, "error": f"{label}: write failed: {e}"}
+    finally:
+        try:
+            ser.close()
+        except Exception:
+            pass
+        slot["state"] = STATE_IDLE if slot["present"] else STATE_ABSENT
+
+    return {
+        "ok": True,
+        "written": written,
+        "matched": matched_line is not None,
+        "line": matched_line,
+        "output": lines,
+    }
+
+
 # ---------------------------------------------------------------------------
 # USB Flap Recovery — unbind USB to stop storm, then recover via GPIO or backoff
 # ---------------------------------------------------------------------------
@@ -1786,6 +1849,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self._handle_serial_reset()
         elif path == "/api/serial/monitor":
             self._handle_serial_monitor()
+        elif path == "/api/serial/write":
+            self._handle_serial_write()
         elif path == "/api/serial/recover":
             self._handle_serial_recover()
         elif path == "/api/serial/release":
@@ -2506,6 +2571,46 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 log_activity(f"serial.monitor({slot_label}) — timeout, no match", "info")
         else:
             log_activity(f"serial.monitor({slot_label}) — {result.get('error', 'failed')}", "error")
+        self._send_json(result)
+
+    def _handle_serial_write(self):
+        body = self._read_json() or {}
+        slot_label = body.get("slot")
+        if not slot_label:
+            self._send_json({"ok": False, "error": "missing 'slot' field"}, 400)
+            return
+        if "data" not in body:
+            self._send_json({"ok": False, "error": "missing 'data' field"}, 400)
+            return
+        slot = _find_slot_by_label(slot_label)
+        if not slot:
+            self._send_json({"ok": False, "error": f"slot '{slot_label}' not found"})
+            return
+        data = body["data"]
+        if not isinstance(data, str):
+            self._send_json({"ok": False, "error": "'data' must be a string"}, 400)
+            return
+        newline = body.get("newline", "\n")
+        if newline not in ("\n", "\r\n", "\r", ""):
+            self._send_json(
+                {"ok": False,
+                 "error": "'newline' must be one of '\\n', '\\r\\n', '\\r', ''"}, 400)
+            return
+        expect = body.get("expect")
+        timeout = float(body.get("timeout", 10))
+        log_activity(
+            f"serial.write({slot_label}, {len(data)} chars, expect={expect!r}, "
+            f"timeout={timeout})", "step")
+        result = serial_write(slot, data, newline, expect, timeout)
+        if result["ok"]:
+            if expect and result.get("matched"):
+                log_activity(f"serial.write({slot_label}) — matched: {result['line']}", "ok")
+            elif expect:
+                log_activity(f"serial.write({slot_label}) — timeout, no match", "info")
+            else:
+                log_activity(f"serial.write({slot_label}) — {result['written']} bytes", "ok")
+        else:
+            log_activity(f"serial.write({slot_label}) — {result.get('error', 'failed')}", "error")
         self._send_json(result)
 
     def _handle_serial_output(self, qs):

--- a/pytest/workbench_driver.py
+++ b/pytest/workbench_driver.py
@@ -348,6 +348,20 @@ class WorkbenchDriver:
         )
         return {k: v for k, v in result.items() if k != "ok"}
 
+    def serial_write(self, slot: str = "SLOT2", data: str = "",
+                     newline: str = "\n",
+                     expect: Optional[str] = None,
+                     timeout: float = 10) -> dict:
+        """POST /api/serial/write — returns {written, matched, line, output}."""
+        body: dict = {"slot": slot, "data": data,
+                      "newline": newline, "timeout": timeout}
+        if expect is not None:
+            body["expect"] = expect
+        result = self._api_post(
+            "/api/serial/write", body, timeout=timeout + 5
+        )
+        return {k: v for k, v in result.items() if k != "ok"}
+
     def enter_portal(self, slot: str = "SLOT2",
                      resets: int = 3) -> dict:
         """POST /api/enter-portal — starts background portal trigger."""

--- a/pytest/workbench_test.py
+++ b/pytest/workbench_test.py
@@ -1412,6 +1412,31 @@ class TestSerialArchitecture:
         assert len(result.get("output", [])) >= 0
 
     @requires_dut
+    def test_wt1908_serial_write_accepted(self, workbench):
+        """WT-1908: serial_write sends a line and reports bytes written."""
+        dev = _find_present_device(workbench)
+        assert dev, "No device connected"
+        slot = dev["label"]
+
+        # A bare newline is inert on any firmware — this checks the write
+        # path itself, not a particular DUT's command set.
+        result = workbench.serial_write(slot, data="", newline="\n", timeout=2)
+        assert result.get("written") == 1
+        assert isinstance(result.get("output"), list)
+
+    @requires_dut
+    def test_wt1909_serial_write_requires_data(self, workbench):
+        """WT-1909: serial_write rejects a request with no 'data' field."""
+        dev = _find_present_device(workbench)
+        assert dev, "No device connected"
+        slot = dev["label"]
+
+        # The portal answers 400, which the driver surfaces as CommandTimeout
+        # (urllib raises HTTPError, a URLError subclass, before the body parses).
+        with pytest.raises((CommandTimeout, CommandError)):
+            workbench._api_post("/api/serial/write", {"slot": slot}, timeout=5)
+
+    @requires_dut
     def test_wt1907_multi_slot_detection(self, workbench):
         """WT-1907: Multiple slots independently detect their chips."""
         devices = workbench.get_devices()


### PR DESCRIPTION
The serial API can read — `/api/serial/monitor` (FR-009) and `/api/serial/output` — but there is no way to write. A DUT that prompts for input over serial therefore cannot be answered through the API at all, which puts every prompt-driven flow out of reach: LoRaWAN key provisioning, firmware CLIs, config menus.

I hit this driving the workbench from an ESPHome/LoRaWAN build tool. Standalone LoRaWAN firmware provisions its keys over a serial prompt, and there was no endpoint that could answer it.

## Design note: why write and read share one connection

`serial_write` writes and then reads the reply on a **single** proxy connection, rather than being a bare write you follow with a separate `/api/serial/monitor` call.

That is forced by the proxy: `plain_rfc2217_server.py` does `srv.listen(1)` and serves one client at a time, and nothing drains the port in between — `_serial_buf` is only ever filled by `serial_reset`. So between a write call closing its connection and a monitor call opening one, anything the device emits is gone. For a prompt/response exchange that is the entire reply, which arrives microseconds after the write.

Hence `data` + optional `expect` in one request.

## API

```
POST /api/serial/write
{"slot": "SLOT2", "data": "AT+JOIN", "newline": "\r\n", "expect": "OK", "timeout": 10}

-> {"ok": true, "written": 9, "matched": true, "line": "OK", "output": ["AT+JOIN", "OK"]}
```

`newline` is restricted to `\n`, `\r\n`, `\r`, or `""`. Local echo is common, so `output` often leads with the sent line.

## Changes

- `pi/portal.py` — `serial_write()` + `_handle_serial_write()` + route. Mirrors the existing `serial_monitor` structure and reuses `_read_serial_lines`; reuses `STATE_MONITORING` rather than adding a state to the FSD model.
- `pytest/workbench_driver.py` — `WorkbenchDriver.serial_write()`
- `mcp/workbench_mcp.py` — `serial_write` tool
- `docs/Embedded-Workbench-FSD.md` — FR-030 + both API tables
- `pytest/workbench_test.py` — WT-1908, WT-1909

## Validation

Deployed to a live Pi workbench and exercised against a real ESP32-S3 in SLOT29:

| Case | Result |
|---|---|
| write `""` + `\n` | `{"ok": true, "written": 1, ...}` |
| missing `data` | HTTP 400, `missing 'data' field` |
| `newline: "XX"` | HTTP 400, newline must be one of ... |
| unknown slot | `{"ok": false, "error": "slot 'SLOT99' not found"}` |

**What I did not verify:** a real prompt/response round trip. None of the three DUTs on my bench emit anything on serial once booted (`serial_monitor` returns empty for all of them), so I could not observe a reply being captured through the new path. The write half is confirmed on hardware; the read-back half is the same `_read_serial_lines` call on the same pyserial object that `serial_monitor` already uses, but I want to be clear that I have not seen an actual answered prompt end to end.

One unrelated thing I noticed while testing: `serial_reset` on an ESP32-S3 native-USB slot returned 1042 single-character "lines" (`r`, `e`, `s`, `e`, `t`, ...) instead of whole boot lines. Pre-existing, not touched here, but it looks like the boot output is arriving with newlines between characters. Happy to file separately if useful.

I have not run `ruff`/`mypy` — not installed in my environment. Files compile clean.