### PR TITLE
AP dnsmasq: resolve the workbench's own name to the AP IP for AP clients

### DIFF
--- a/pi/wifi_controller.py
+++ b/pi/wifi_controller.py
@@ -313,6 +313,14 @@ def ap_start(ssid, password="", channel=6, dns_logging=False, internet=False):
             "no-resolv",
             "no-daemon",
             "log-dhcp",
+            # Answer the workbench's own name with the AP IP. Without
+            # this, dnsmasq serves the Pi's stock /etc/hosts entry
+            # (`127.0.1.1 workbench`), so an AP client whose mDNS query
+            # loses the race resolves the workbench to ITS OWN loopback
+            # and sends (e.g.) UDP logs silently nowhere. Found root-
+            # causing a DUT's first-boot-only UDP log loss, 2026-07-18.
+            "no-hosts",
+            f"host-record=workbench,workbench.local,{AP_IP}",
         ]
         if dns_logging or internet:
             dnsmasq_lines += ["server=8.8.8.8", "server=8.8.4.4"]


### PR DESCRIPTION
Hi — first off, thank you for everything you've put out on YouTube over the
years. I've learned a huge amount from your channel, and this workbench
project has been a great foundation to build test tooling on top of.

While using it I ran into a small but sneaky DNS bug and wanted to send the
fix back in case it helps others too. I used Claude to help track this down
and write the patch, flagging that up front. I tried to keep it a general
fix rather than something specific to my own setup — let me know if anything
here doesn't fit how you'd want it done.

**Why**

An AP client that falls back from mDNS to unicast DNS for
`workbench`/`workbench.local` hits dnsmasq — which was passing through the
Pi's own `/etc/hosts` entry, `127.0.1.1 workbench`. That's the Pi's own
loopback, not the AP IP, so any client-initiated traffic aimed at the
workbench by name resolves to the *client's own* loopback and goes nowhere.
No error on either side — it just silently fails.

This showed up as a DUT losing its entire first-boot burst of UDP debug
logs: it resolved `workbench.local`, got back a loopback address, and
shipped its logs into the void before anything was listening for the
failure.

**Fix**

`no-hosts` stops dnsmasq from serving that stale `/etc/hosts` entry to AP
clients, and an explicit `host-record` pins `workbench`/`workbench.local` to
the actual AP IP instead.

**Test plan**
- [ ] Join a client to the AP, confirm `ping workbench.local` resolves to
      the AP IP (not `127.0.0.1`)
- [ ] Reproduce the original DUT first-boot UDP log scenario and confirm
      logs arrive

Thanks again for all the content — hope this is a useful small contribution
back.
