### PR TITLE
A bench named on purpose loses that name on every update

### DIFF
--- a/docs/Harness-User-Manual.md
+++ b/docs/Harness-User-Manual.md
@@ -106,6 +106,19 @@ settings:
 - **WiFi:** configure your network (country code as needed)
 - **Locale:** set timezone as needed
 
+Note that `install.sh` renames the host to `testbench-XXXX`, where `XXXX` is
+the last four hex digits of the wlan0 MAC, so whatever you set here is
+replaced on the first install — and again on every later one, since the rename
+is not a one-time step. To keep a name you chose deliberately:
+
+```bash
+sudo mkdir -p /etc/rfc2217 && sudo touch /etc/rfc2217/keep-hostname
+```
+
+The installer then reports `Keeping host '<name>'` and leaves it alone. If you
+change the hostname by hand, change the `127.0.1.1` line in `/etc/hosts` to
+match in the same breath, or every `sudo` stalls on "unable to resolve host".
+
 ### 2.2 First boot — system hardening
 
 These changes prevent the OOM crash cycle that kills Pi Zero 2 W boards (512 MB).

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -215,7 +215,18 @@ MAC_IF=wlan0
 MAC_SUFFIX="$(sed 's/://g' "/sys/class/net/$MAC_IF/address" 2>/dev/null | tail -c 5)"
 CURRENT_HOST="$(hostname)"
 
-if [ -n "$MAC_SUFFIX" ]; then
+# A bench can be named on purpose -- for its site, its owner, its rack slot --
+# and the rename above runs on *every* install, not once. Without an opt-out a
+# chosen name silently reverts the next time someone updates, which reads as
+# the machine renaming itself. The manual already says the hostname is for
+# humans and the address is what tools use, so let the human keep theirs.
+#
+# A marker file rather than a config key: this runs before the portal's config
+# is read, and the decision has to be legible from a shell prompt on a bench
+# that may not be answering HTTP yet.
+if [ -f /etc/rfc2217/keep-hostname ]; then
+    echo "Keeping host '$CURRENT_HOST' (/etc/rfc2217/keep-hostname present)"
+elif [ -n "$MAC_SUFFIX" ]; then
     WANT_HOST="testbench-${MAC_SUFFIX}"
     if [ "$CURRENT_HOST" != "$WANT_HOST" ]; then
         echo "Renaming host '$CURRENT_HOST' -> '$WANT_HOST' (from $MAC_IF MAC)"


### PR DESCRIPTION
## The problem

The hostname step renames to `testbench-<MAC>` whenever the current name differs — and `install.sh` is also the *update* path, so this is not a one-time provisioning step. A bench named for its site, its owner or its rack position gets that name taken back the next time someone runs `--update`, with nothing in the update's purpose to suggest it would.

From the operator's side the machine appears to have renamed itself. I hit this updating a bench to v1.0.1: it had been `wyola-workbench` for months and came back as `testbench-f45b`.

## Why an opt-out rather than dropping the scheme

The derived name is a good default and I'd keep it. The manual already makes the case for allowing an override, though:

> The hostname is for humans reading `hostnamectl`; the address is what tools use.

Nothing functional depends on the name — the portal reports `host_ip`, the docs are emphatic about addressing the bench by IP, and mDNS is already ruled out for containers. So it's a sensible default, not a requirement.

## The change

```bash
if [ -f /etc/rfc2217/keep-hostname ]; then
    echo "Keeping host '$CURRENT_HOST' (/etc/rfc2217/keep-hostname present)"
elif [ -n "$MAC_SUFFIX" ]; then
```

Default behaviour is unchanged when the marker is absent.

A **marker file** rather than a key in `testbench.json`, for two reasons: this runs before the portal's config is read, and the decision has to be legible from a shell prompt on a bench that may not be answering HTTP yet.

## Docs

Two gaps this also closes, both found the hard way:

- §2.1 tells you to choose a hostname at imaging time and doesn't mention that the installer replaces it — let alone that it keeps replacing it. Now documented, with the opt-out.
- `install.sh` warns in a comment that a hostname/`/etc/hosts` mismatch stalls every `sudo` on "unable to resolve host". That warning exists nowhere a user would read, and it bites anyone who sets the hostname by hand. Now in the manual.

## Verification

On a live Pi 3B running v1.0.1:

- marker present → `Keeping host 'wyola-workbench'`, name survives a full `install.sh --update`
- marker absent → renames to `testbench-f45b` exactly as before
- `bash -n` clean; `sudo` responds in 0.8s after aligning `/etc/hosts`
- portal reports the kept name, all 31 slots enumerate, 3 attached boards unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)